### PR TITLE
Migrate to the stable Akka Stream release.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,15 +2,13 @@ name := "acked-streams"
 
 organization := "com.timcharper"
 
-version := "2.0"
-
 scalaVersion := "2.11.7"
 
 crossScalaVersions := Seq("2.11.7", "2.10.5")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-stream-experimental" % "2.0.1",
-  "org.scalatest"     %% "scalatest"                % "2.2.1" % "test")
+  "com.typesafe.akka" %% "akka-stream"  % "2.4.2",
+  "org.scalatest"     %% "scalatest"    % "2.2.1" % "test")
 
 homepage := Some(url("https://github.com/timcharper/acked-stream"))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11

--- a/src/main/scala/com/timcharper/acked/AckedSource.scala
+++ b/src/main/scala/com/timcharper/acked/AckedSource.scala
@@ -1,9 +1,11 @@
 package com.timcharper.acked
 
+import akka.{Done, NotUsed}
 import akka.pattern.pipe
 import akka.stream.Attributes
 import akka.stream.{Graph, Materializer}
 import akka.stream.scaladsl.{Keep, RunnableGraph, Source}
+
 import scala.annotation.tailrec
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.{Future, Promise}
@@ -24,7 +26,7 @@ class AckedSource[+Out, +Mat](val wrappedRepr: Source[AckTup[Out], Mat]) extends
    * Connect this [[akka.stream.scaladsl.Source]] to a [[akka.stream.scaladsl.Sink]],
    * concatenating the processing steps of both.
    */
-  def runAckMat[Mat2](combine: (Mat, Future[Unit]) ⇒ Mat2)(implicit materializer: Materializer): Mat2 =
+  def runAckMat[Mat2](combine: (Mat, Future[Done]) ⇒ Mat2)(implicit materializer: Materializer): Mat2 =
     wrappedRepr.toMat(AckedSink.ack.akkaSink)(combine).run
 
   def runAck(implicit materializer: Materializer) = runAckMat(Keep.right)
@@ -32,7 +34,7 @@ class AckedSource[+Out, +Mat](val wrappedRepr: Source[AckTup[Out], Mat]) extends
   def runWith[Mat2](sink: AckedSink[Out, Mat2])(implicit materializer: Materializer): Mat2 =
     wrappedRepr.runWith(sink.akkaSink)
 
-  def runForeach(f: (Out) ⇒ Unit)(implicit materializer: Materializer): Future[Unit] =
+  def runForeach(f: (Out) ⇒ Unit)(implicit materializer: Materializer): Future[Done] =
     runWith(AckedSink.foreach(f))
 
   def to[Mat2](sink: AckedSink[Out, Mat2]): RunnableGraph[Mat] =
@@ -88,7 +90,7 @@ trait AckedSourceMagnet {
 }
 object AckedSourceMagnet extends LowerPriorityAckedSourceMagnet {
   implicit def fromPromiseIterable[T](iterable: scala.collection.immutable.Iterable[AckTup[T]]) = new AckedSourceMagnet {
-    type Out = AckedSource[T, Unit]
+    type Out = AckedSource[T, NotUsed]
     def apply = new AckedSource(Source(iterable))
   }
 
@@ -100,12 +102,12 @@ object AckedSourceMagnet extends LowerPriorityAckedSourceMagnet {
 
 private[acked] abstract class LowerPriorityAckedSourceMagnet {
   implicit def fromIterable[T](iterable: scala.collection.immutable.Iterable[T]) = new AckedSourceMagnet {
-    type Out = AckedSource[T, Unit]
-    def apply = new AckedSource(Source(Stream.continually(Promise[Unit]) zip iterable))
+    type Out = AckedSource[T, NotUsed]
+    def apply = new AckedSource(Source(Stream.continually(Promise[Unit]()) zip iterable))
   }
 
   implicit def fromSource[T, M](source: Source[T, M]) = new AckedSourceMagnet {
     type Out = AckedSource[T, M]
-    def apply = new AckedSource(source.map(d => (Promise[Unit], d)))
+    def apply = new AckedSource(source.map(d => (Promise[Unit](), d)))
   }
 }

--- a/src/main/scala/com/timcharper/acked/Components.scala
+++ b/src/main/scala/com/timcharper/acked/Components.scala
@@ -1,8 +1,10 @@
 package com.timcharper.acked
 
+import akka.NotUsed
 import akka.stream._
 import akka.stream.scaladsl._
 import akka.stream.stage._
+
 import scala.concurrent._
 
 object Components {
@@ -28,7 +30,7 @@ object Components {
 
     @return An AckedFlow which runs the bundling buffer component.
     */
-  def bundlingBuffer[T](size: Int, overflowStrategy: OverflowStrategy): AckedFlow[T, T, Unit] = AckedFlow {
+  def bundlingBuffer[T](size: Int, overflowStrategy: OverflowStrategy): AckedFlow[T, T, NotUsed] = AckedFlow {
     Flow[(Promise[Unit], T)].transform( () =>
       new BundlingBuffer(size, overflowStrategy)
     )

--- a/src/main/scala/com/timcharper/acked/package.scala
+++ b/src/main/scala/com/timcharper/acked/package.scala
@@ -1,8 +1,19 @@
 package com.timcharper
 
+import scala.concurrent.ExecutionContext
+
 package object acked {
 
   import scala.concurrent.Promise
 
   type AckTup[T] = (Promise[Unit], T)
+
+  // WARNING!!! Don't block inside of Runnable (Future) that uses this.
+  private[acked] object SameThreadExecutionContext extends ExecutionContext {
+    def execute(r: Runnable): Unit =
+      r.run()
+    override def reportFailure(t: Throwable): Unit =
+      throw new IllegalStateException("problem in op_rabbit internal callback", t)
+  }
+
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "2.1.0-SNAPSHOT"


### PR DESCRIPTION
This commit removes the dependency on the experimental version of Akka Streams.
